### PR TITLE
Update download URL for kubectl

### DIFF
--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 # stable will be automatically be replaced with the latest stable version.
 # Otherwise, this should be a version, with or without leading v.
 ARG K8S_VERSION=stable
-ARG K8S_DWROOT=https://storage.googleapis.com/kubernetes-release/release
+ARG K8S_DWROOT=https://dl.k8s.io/release
 
 # latest is the default, otherwise this should be the version of krew with the
 # leading v.


### PR DESCRIPTION
The old `storage.googleapis.com` download URL for kubectl no longer works, which meant that recent builds of the `kubectl` image have a zero-length file at `/usr/local/bin/kubectl` instead of the real binary.

### Current image pulled from ghcr (or docker hub)

```
$ docker run --rm -it --entrypoint ash ghcr.io/efrecon/kubectl:v1.32.1
/ # kubectl
/ # echo $?
0
/ # ls -l /usr/local/bin
total 13636
-rwxr-xr-x    1 root     root          1815 May  2 01:02 bininstall.sh
-rwxr-xr-x    1 root     root             0 May  2 01:03 kubectl
-rwxr-xr-x    1 501      dialout   13952477 Jan  1  2000 kubectl-krew
-rwxr-xr-x    1 root     root          2549 May  2 01:02 tarinstall.sh
/ # 
```

### Locally-built image from this PR branch

```
$ docker run --rm -it --entrypoint ash efrecon-kubectl:v1.32.1
/ # kubectl
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/

Basic Commands (Beginner):
  create          Create a resource from a file or from stdin
  expose          Take a replication controller, service, deployment or pod and expose it as a new Kubernetes service
  run             Run a particular image on the cluster
  set             Set specific features on objects
[... long output truncated ...]
/ # echo $?
0
/ # ls -l /usr/local/bin
total 69620
-rwxr-xr-x    1 root     root          1815 May  2 10:49 bininstall.sh
-rwxr-xr-x    1 root     root      57323672 May  2 10:51 kubectl
-rwxr-xr-x    1 501      dialout   13952477 Jan  1  2000 kubectl-krew
-rwxr-xr-x    1 root     root          2549 May  2 10:49 tarinstall.sh
/ # 
```

Fixes #3